### PR TITLE
Added a sample systemd service file

### DIFF
--- a/laserweb3.service
+++ b/laserweb3.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=Laserweb3 node.js service
+
+[Service]
+ExecStart=/usr/local/bin/node /home/pi/LaserWeb3/server-smoothie.js
+Restart=always
+RestartSec=10                       # Restart service after 10 seconds if node service crashes
+StandardOutput=syslog               # Output to syslog
+StandardError=syslog                # Output to syslog
+SyslogIdentifier=laserweb3
+WorkingDirectory=/home/pi/LaserWeb3
+User=pi
+#Group=<alternate group>
+Environment=NODE_ENV=production PORT=8000
+
+[Install]
+WantedBy=multi-user.target
+


### PR DESCRIPTION
This file is used by systemd... Its the modern equivalent of /etc/init.d/laserweb3, sorta. Its used to auto-start LW at boot, and also allows systemd to restart it if it exits, and other such service controls. This is only tested on debian, but it should work on all major linuxes.  dirs and usernames may need to be changed.
