### PR TITLE
Fixed SVGReader.js to be callable as a library from outside a browser

### DIFF
--- a/public/lib/svgreader/SVGReader.js
+++ b/public/lib/svgreader/SVGReader.js
@@ -32,6 +32,9 @@ ToDo:
 * check for out of bounds geometry
 */
 
+if(typeof require === 'function') {
+    var Vec2 = require(__dirname + '/vec2.js').Vec2
+}
 
 SVGReader = {
 
@@ -154,7 +157,9 @@ SVGReader = {
 
         // parse xml
         var svgRootElement;
-        if (window.DOMParser) {
+        var isBrowserEnv = typeof window !== 'undefined'
+        if (!isBrowserEnv || window.DOMParser) {
+            var DOMParser = isBrowserEnv ? window.DOMParser : require('xmldom').DOMParser
             var parser = new DOMParser();
             svgRootElement = parser.parseFromString(svgstring, 'text/xml').documentElement;
         }
@@ -267,6 +272,7 @@ SVGReader = {
                         //console.log('Stroke: '+node.stroke+ ' of type '+ typeof(node.stroke));
                         //console.log('Stroke: '+parsecolor+ ' of type '+ typeof(parsecolor));
                         // Compare object values - as per http://stackoverflow.com/questions/1068834/object-comparison-in-javascript
+                        var parsecolor;
                         if (parsecolor) {
                             if (JSON.stringify(node.stroke) === JSON.stringify(parsecolor) ) {
                                 this.boundarys.allcolors.push(subpath);
@@ -1273,4 +1279,8 @@ if (typeof(String.prototype.strip) === "undefined") {
     String.prototype.strip = function() {
         return String(this).replace(/^\s+|\s+$/g, '');
     };
+}
+
+if(typeof module !== 'undefined' && module.exports){
+    module.exports.SVGReader = SVGReader
 }

--- a/public/lib/svgreader/vec2.js
+++ b/public/lib/svgreader/vec2.js
@@ -287,3 +287,8 @@ Vec2.prototype = {
     return new Vec2(-this.y, this.x)
   }
 };
+
+if(typeof module !== 'undefined' && module.exports){
+    module.exports.Vec2 = Vec2
+}
+


### PR DESCRIPTION
This PR allows the SVG reading library to be called from a Node.js environment.

The idea behind this is that I want to use parts of LaserWeb3 as a library from Node and the first parts I'm trying to isolate are the SVG to G-Code and cost-estimation bits.

Is that direction (making code a bit more modular, allowed to use as library) something that would of interest to push to the main repository?
